### PR TITLE
Remove dependency on glibc entirely

### DIFF
--- a/arm_chainloader/Makefile
+++ b/arm_chainloader/Makefile
@@ -43,7 +43,7 @@ OBJ := $(addprefix build/, $(addsuffix .o, $(basename $(SRCS))))
 
 include $(OBJ:.o=.d)
 
-LINKFLAGS = -nostdlib -march=$(ARCH) -Wl,--build-id=none -T linker.lds -ltlsf -lgcc -lcommon -lnotc -lstdc++ -Wl,--gc-sections -ltlsf
+LINKFLAGS = -nostdlib -march=$(ARCH) -Wl,--build-id=none -T linker.lds -ltlsf -lgcc -lcommon -lnotc -Wl,--gc-sections -ltlsf
 FPUFLAGS=-mfpu=vfp -mfloat-abi=softfp
 
 # applied to as, gcc and g++
@@ -103,7 +103,7 @@ build/arm_chainloader.bin: build/arm_chainloader.elf
 
 build/arm_chainloader.elf: $(OBJ)
 	@echo $(WARN_COLOR)LD  $(NO_COLOR) $@
-	$(CC) $(OBJ) $(LINKFLAGS) -o $@ -Wl,-Map=build/arm_chainloader.map
+	$(CXX) $(OBJ) $(LINKFLAGS) -o $@ -Wl,-Map=build/arm_chainloader.map
 
 clean:
 	@echo $(ERROR_COLOR)CLEAN$(NO_COLOR)

--- a/notc/include/inttypes.h
+++ b/notc/include/inttypes.h
@@ -1,0 +1,1 @@
+#include "stdint.h"

--- a/notc/include/stdint.h
+++ b/notc/include/stdint.h
@@ -1,0 +1,25 @@
+#ifndef __STDINT_H
+#define __STDINT_H
+#include <stddef.h>
+#if __SIZEOF_INT__ == 4
+typedef unsigned int uint32_t;
+#else
+#warning "unknown uint32_t"
+#endif
+#if __SIZEOF_SHORT__ == 2
+typedef unsigned short uint16_t;
+#else
+#warning "unknown uint16_t"
+#endif
+typedef unsigned char uint8_t;
+#if __SIZEOF_LONG_LONG__ == 8
+typedef unsigned long long uint64_t;
+#else
+#warning "unknown uint64_t"
+#endif
+#if __SIZEOF_LONG__ == __SIZEOF_POINTER__
+typedef unsigned long uintptr_t;
+#else
+#warning "unknown uintptr_t"
+#endif
+#endif /* ndef __STDINT_H */

--- a/notc/include/stdio.h
+++ b/notc/include/stdio.h
@@ -1,0 +1,15 @@
+#ifndef __STDIO_H
+#define __STDIO_H
+#include <stdarg.h>
+#include "xprintf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int putchar (int c);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* ndef __STDIO_H */

--- a/notc/include/string.h
+++ b/notc/include/string.h
@@ -1,0 +1,18 @@
+#ifndef __STRING_H
+#define __STRING_H
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void memcpy(void* dest, const void* src, size_t n); /* builtin */
+void memset(void* s, int c, size_t n);
+int strlen(const char* s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __STRING_H */

--- a/notc/include/strings.h
+++ b/notc/include/strings.h
@@ -1,0 +1,3 @@
+#ifndef __STRINGS_H
+#define __STRINGS_H
+#endif /* ndef __STRINGS_H */

--- a/notc/include/sys/types.h
+++ b/notc/include/sys/types.h
@@ -1,0 +1,3 @@
+#ifndef __SYS_TYPES_H
+#define __SYS_TYPES_H
+#endif /* ndef __SYS_TYPES_H */

--- a/notc/include/xprintf.h
+++ b/notc/include/xprintf.h
@@ -23,7 +23,7 @@ extern "C" {
 int puts (const char* str);
 int printf (const char* fmt, ...) __attribute__ ((format (printf, 1, 2)));
 void put_dump (const void* buff, unsigned long addr, int len, int width);
-void uart_putc(unsigned int ch);
+void uart_putc(char ch);
 
 
 int vprintf (


### PR DESCRIPTION
We have packaged this in GNU Guix and had to fix a few build problems in order to package it successfully.

We use isolated build containers and a cross-compiler WITHOUT glibc.

It seems that the intent of rpi-open-firmware's implementation was to work without glibc.

However, a few places in the implementation still required glibc *header* files.

In order to prevent a dependency on glibc even in small things, we provide stubs for libc functions in `notc/include`.

Also, we changed the linker command `gcc -lstdc++` to `g++` because that's the official way to do it (and we had a build failure with the other way).

Also, we fixed a type mismatch in `uart_putc` in `notc/include/xprintf.h`.

This patchset causes derivations for rpi-open-firmware to be built successfully in GNU Guix.